### PR TITLE
Inventory packet fixes

### DIFF
--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/packet/InventoryContentPacket.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/packet/InventoryContentPacket.java
@@ -4,15 +4,15 @@ import com.nukkitx.protocol.bedrock.BedrockPacket;
 import com.nukkitx.protocol.bedrock.BedrockPacketType;
 import com.nukkitx.protocol.bedrock.data.inventory.ItemData;
 import com.nukkitx.protocol.bedrock.handler.BedrockPacketHandler;
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectRBTreeMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectSortedMap;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(doNotUseGetters = true, callSuper = false)
 public class InventoryContentPacket extends BedrockPacket {
-    private final Int2ObjectMap<ItemData> entries = new Int2ObjectOpenHashMap<>();
+    private final Int2ObjectSortedMap<ItemData> entries = new Int2ObjectRBTreeMap<>();
     private int containerId;
 
     @Override

--- a/bedrock/bedrock-v407/src/main/java/com/nukkitx/protocol/bedrock/v407/serializer/InventorySlotSerializer_v407.java
+++ b/bedrock/bedrock-v407/src/main/java/com/nukkitx/protocol/bedrock/v407/serializer/InventorySlotSerializer_v407.java
@@ -14,17 +14,17 @@ public class InventorySlotSerializer_v407 implements BedrockPacketSerializer<Inv
 
     @Override
     public void serialize(ByteBuf buffer, BedrockPacketHelper helper, InventorySlotPacket packet) {
-        VarInts.writeInt(buffer, packet.getNetworkId());
         VarInts.writeUnsignedInt(buffer, packet.getContainerId());
         VarInts.writeUnsignedInt(buffer, packet.getSlot());
+        VarInts.writeInt(buffer, packet.getNetworkId());
         helper.writeItem(buffer, packet.getItem());
     }
 
     @Override
     public void deserialize(ByteBuf buffer, BedrockPacketHelper helper, InventorySlotPacket packet) {
-        packet.setNetworkId(VarInts.readInt(buffer));
         packet.setContainerId(VarInts.readUnsignedInt(buffer));
         packet.setSlot(VarInts.readUnsignedInt(buffer));
+        packet.setNetworkId(VarInts.readInt(buffer));
         packet.setItem(helper.readItem(buffer));
     }
 }


### PR DESCRIPTION
Not sure if the sorted map is the optimal solution.
The purpose of sorting is so the entries are written in order in the serializer, or else bugs occur.
https://github.com/bundabrg/Protocol/blob/4c7bd5a9ad0d65c72f4b88273b58365080b8c9d6/bedrock/bedrock-v407/src/main/java/com/nukkitx/protocol/bedrock/v407/serializer/InventoryContentSerializer_v407.java#L22-L26